### PR TITLE
Jit parallel

### DIFF
--- a/ncempy_4dgui/__init__.py
+++ b/ncempy_4dgui/__init__.py
@@ -429,10 +429,10 @@ class fourD(QWidget):
         """
         dp = np.zeros((frame_dimensions[0] * frame_dimensions[1]), np.uint32)
         # nested for loop for: scan_dimension0, scan_dimension1, num_frame, event
-        for ii in range(frames.shape[0]):
-            for jj in range(frames.shape[1]):
-                for kk in range(frames.shape[2]):
-                    for ll in range(frames.shape[3]):
+        for ii in prange(frames.shape[0]):
+            for jj in prange(frames.shape[1]):
+                for kk in prange(frames.shape[2]):
+                    for ll in prange(frames.shape[3]):
                         pos = frames[ii, jj, kk, ll]
                         if pos > 0:
                             dp[pos] += 1

--- a/ncempy_4dgui/__init__.py
+++ b/ncempy_4dgui/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pyqtgraph as pg
 import numpy as np
 from tifffile import imsave
-from numba import jit
+from numba import jit, prange
 from numba.types.containers import UniTuple
 import stempy.io as stio
 
@@ -365,7 +365,7 @@ class fourD(QWidget):
         self.real_space_image_item.setImage(im, autoRange=True)
 
     @staticmethod
-    @jit(["uint32[:](uint32[:,:,:], uint32[:,:,:], int64, int64, int64, int64)"], nopython=True, nogil=True, parallel=True)
+    @jit(["uint32[:](uint32[:,:,:], uint32[:,:,:], int64, int64, int64, int64)"], nopython=True, nogil=True, parallel=False)
     def getImage_jit(rows, cols, left, right, bot, top):
         """ Sum number of electron strikes within a square box
         significant speed up using numba.jit compilation.
@@ -392,7 +392,7 @@ class fourD(QWidget):
         im = np.zeros(rows.shape[0], dtype=np.uint32)
         
         # For each scan position (ii) sum all events (kk) in each frame (jj)
-        for ii in range(im.shape[0]):
+        for ii in prange(im.shape[0]):
             ss = 0
             for jj in range(rows.shape[1]):
             	for kk in range(rows.shape[2]):

--- a/ncempy_4dgui/__init__.py
+++ b/ncempy_4dgui/__init__.py
@@ -365,7 +365,7 @@ class fourD(QWidget):
         self.real_space_image_item.setImage(im, autoRange=True)
 
     @staticmethod
-    @jit(["uint32[:](uint32[:,:,:], uint32[:,:,:], int64, int64, int64, int64)"], nopython=True, nogil=True, parallel=False)
+    @jit(["uint32[:](uint32[:,:,:], uint32[:,:,:], int64, int64, int64, int64)"], nopython=True, nogil=True, parallel=True)
     def getImage_jit(rows, cols, left, right, bot, top):
         """ Sum number of electron strikes within a square box
         significant speed up using numba.jit compilation.


### PR DESCRIPTION
Use jit prange to speed up computation by parallelization. Large speed up for summing in diffraction space.